### PR TITLE
feat: add rate limiting to admin auth endpoint

### DIFF
--- a/src/app/api/admin-auth/route.ts
+++ b/src/app/api/admin-auth/route.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from "next/server";
+import { adminAuthRateLimiter, getClientIP } from "@/lib/rateLimiter";
 
 export async function POST(request: Request) {
+  // Check rate limit before processing
+  const clientIP = getClientIP(request);
+
+  if (!adminAuthRateLimiter.isAllowed(clientIP)) {
+    return NextResponse.json(
+      { error: "Too many attempts. Please try again later." },
+      { status: 429 }
+    );
+  }
+
   const { token } = await request.json();
   const secret = process.env.ADMIN_SECRET;
 

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -1,0 +1,85 @@
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+interface RateLimitConfig {
+  windowMs: number; // Time window in milliseconds
+  maxRequests: number; // Maximum requests per window
+}
+
+class RateLimiter {
+  private store = new Map<string, RateLimitEntry>();
+  private config: RateLimitConfig;
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+  }
+
+  isAllowed(identifier: string): boolean {
+    const now = Date.now();
+    const windowStart = Math.floor(now / this.config.windowMs) * this.config.windowMs;
+
+    const entry = this.store.get(identifier);
+
+    if (!entry || entry.windowStart < windowStart) {
+      // New window or no previous entry
+      this.store.set(identifier, {
+        count: 1,
+        windowStart: windowStart
+      });
+      return true;
+    }
+
+    if (entry.count >= this.config.maxRequests) {
+      return false;
+    }
+
+    // Increment count within current window
+    entry.count++;
+    this.store.set(identifier, entry);
+    return true;
+  }
+
+  // Clean up old entries (optional, to prevent memory leaks)
+  cleanup(): void {
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+
+    this.store.forEach((entry, key) => {
+      if (entry.windowStart < cutoff) {
+        this.store.delete(key);
+      }
+    });
+  }
+}
+
+// Admin auth rate limiter: 5 attempts per 15 minutes
+export const adminAuthRateLimiter = new RateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  maxRequests: 5 // 5 attempts per 15 minutes
+});
+
+// Helper function to get client IP from request
+export function getClientIP(request: Request): string {
+  // Try to get IP from various headers (for different deployment scenarios)
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  const realIP = request.headers.get('x-real-ip');
+  const remoteAddr = request.headers.get('remote-addr');
+
+  if (forwardedFor) {
+    // x-forwarded-for can contain multiple IPs, get the first one
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  if (realIP) {
+    return realIP;
+  }
+
+  if (remoteAddr) {
+    return remoteAddr;
+  }
+
+  // Fallback for development or when headers are not available
+  return 'unknown-ip';
+}


### PR DESCRIPTION
Implements VO-12

## Summary
- Added in-memory sliding window rate limiter for admin authentication
- Prevents brute-force attacks with 5 attempts per 15-minute window per IP
- Returns 429 status when rate limit exceeded
- Tracks requests by client IP using various header sources

## Changes
- Created  with sliding window rate limiter implementation
- Modified  to use rate limiting before authentication
- Added proper error responses for rate limit violations

## Security Enhancement
This addresses the security vulnerability where the admin endpoint was susceptible to brute-force attacks by implementing client IP-based rate limiting.