### PR TITLE
Add sr-only label to search input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -192,8 +192,12 @@ export default function HomePage() {
             </p>
           </div>
           <div className="relative w-full sm:w-72">
+            <label htmlFor="match-search" className="sr-only">
+              Maç arama
+            </label>
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" />
             <input
+              id="match-search"
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}


### PR DESCRIPTION
Implements VO-50: Add accessibility label to search input for screen reader users

## Changes
- Added sr-only label element to search input
- Connected label to input with proper id and htmlFor attributes
- Improves accessibility compliance for screen reader users

## Testing
- ESLint passes without errors
- No breaking changes introduced
- Maintains existing functionality while improving accessibility