### PR TITLE
Convert img tags to next/image Image component

### DIFF
--- a/src/app/dashboard/videos/page.tsx
+++ b/src/app/dashboard/videos/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import Image from "next/image";
 import {
   Video,
   Search,
@@ -195,9 +196,11 @@ export default function DashboardVideosPage() {
                 className="flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900 p-3"
               >
                 {result.thumbnail ? (
-                  <img
+                  <Image
                     src={result.thumbnail}
                     alt={result.title}
+                    width={96}
+                    height={64}
                     className="h-16 w-24 shrink-0 rounded-md object-cover"
                   />
                 ) : (

--- a/src/app/hakemler/[slug]/page.tsx
+++ b/src/app/hakemler/[slug]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, use } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { matchUrl } from "@/lib/links";
 import {
@@ -126,9 +127,11 @@ export default function HakemDetailPage({
       <div className="mb-10 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-8">
         <div className="flex flex-col items-center text-center sm:flex-row sm:items-start sm:text-left">
           {referee.photoUrl ? (
-            <img
+            <Image
               src={referee.photoUrl}
               alt={referee.name}
+              width={96}
+              height={96}
               className="mb-4 h-24 w-24 rounded-full object-cover sm:mb-0 sm:mr-6"
             />
           ) : (

--- a/src/app/profil/page.tsx
+++ b/src/app/profil/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { useEffect, useState, useRef } from "react";
 import { Loader2, User, Camera, Save, MessageSquare, Send } from "lucide-react";
 import Link from "next/link";
@@ -196,10 +197,9 @@ export default function ProfilPage() {
             <div className="relative">
               <div className="flex h-24 w-24 overflow-hidden rounded-full border-2 border-zinc-700 bg-zinc-800">
                 {session?.user?.image ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
+                  <Image
                     src={session.user.image}
-                    alt="Profil"
+                    alt={session.user.name || "Profil"}
                     width={96}
                     height={96}
                     className="h-24 w-24 object-cover"

--- a/src/components/CommentSection.tsx
+++ b/src/components/CommentSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
+import Image from "next/image";
 import { MessageSquare, Send, Loader2, User, ThumbsUp, ThumbsDown, HelpCircle, Reply, Flag } from "lucide-react";
 import AuthModal from "./AuthModal";
 import ReportModal from "./ReportModal";
@@ -200,8 +201,7 @@ export default function CommentSection({ matchId, incidentId }: CommentSectionPr
           <div className="mb-4 flex items-center gap-2">
             <div className="flex h-8 w-8 overflow-hidden rounded-full bg-zinc-800">
               {session.user.image ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={session.user.image} alt="" width={32} height={32} className="h-8 w-8 object-cover" />
+                <Image src={session.user.image} alt={session.user.name || "User"} width={32} height={32} className="h-8 w-8 object-cover" />
               ) : (
                 <div className="flex h-full w-full items-center justify-center">
                   <User className="h-4 w-4 text-zinc-500" />
@@ -351,8 +351,7 @@ export default function CommentSection({ matchId, incidentId }: CommentSectionPr
                     <div className="flex items-center gap-2">
                       <div className="flex h-7 w-7 overflow-hidden rounded-full bg-zinc-800">
                         {comment.image ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img src={comment.image} alt="" width={28} height={28} className="h-7 w-7 object-cover" />
+                          <Image src={comment.image} alt={comment.author} width={28} height={28} className="h-7 w-7 object-cover" />
                         ) : (
                           <div className="flex h-full w-full items-center justify-center">
                             <User className="h-3.5 w-3.5 text-zinc-400" />
@@ -432,8 +431,7 @@ export default function CommentSection({ matchId, incidentId }: CommentSectionPr
                         <div key={r.id} className="flex gap-2">
                           <div className="flex h-6 w-6 shrink-0 overflow-hidden rounded-full bg-zinc-800">
                             {r.image ? (
-                              // eslint-disable-next-line @next/next/no-img-element
-                              <img src={r.image} alt="" width={24} height={24} className="h-6 w-6 object-cover" />
+                              <Image src={r.image} alt={r.author} width={24} height={24} className="h-6 w-6 object-cover" />
                             ) : (
                               <div className="flex h-full w-full items-center justify-center">
                                 <User className="h-3 w-3 text-zinc-500" />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { Shield, Send, Scale, ListFilter, Menu, X, UserRound, User, LogOut } from "lucide-react";
@@ -63,8 +64,7 @@ export default function Navbar() {
               >
                 <div className="flex h-7 w-7 overflow-hidden rounded-full bg-zinc-800">
                   {session.user.image ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={session.user.image} alt="" width={28} height={28} className="h-7 w-7 object-cover" />
+                    <Image src={session.user.image} alt={session.user.name || "User"} width={28} height={28} className="h-7 w-7 object-cover" />
                   ) : (
                     <div className="flex h-full w-full items-center justify-center">
                       <User className="h-4 w-4 text-zinc-500" />


### PR DESCRIPTION
## Summary
- Converted all `<img>` tags to Next.js `Image` component for optimal performance
- Added automatic image optimization, lazy loading, and WebP/AVIF conversion support  
- Improved accessibility with meaningful alt text descriptions
- Added proper width/height props for layout stability and CLS prevention
- Removed ESLint disable comments as they're no longer needed

## Changes
- **Navbar.tsx**: User profile image conversion
- **CommentSection.tsx**: Comment and reply author images conversion  
- **profil/page.tsx**: Profile page user image conversion
- **hakemler/[slug]/page.tsx**: Referee photo conversion
- **dashboard/videos/page.tsx**: Video thumbnail conversion

## Benefits
- ✅ Automatic image optimization and modern format serving
- ✅ Built-in lazy loading for better performance
- ✅ Layout stability with explicit dimensions
- ✅ Better accessibility with improved alt text
- ✅ Next.js Image optimization features enabled

**Implements VO-28**