### PR TITLE
Hash admin token before storing in cookie

### DIFF
--- a/src/app/api/admin-auth/route.ts
+++ b/src/app/api/admin-auth/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { adminAuthRateLimiter, getClientIP } from "@/lib/rateLimiter";
+import { validateAndHashAdminToken } from "@/utils/auth";
 
 export async function POST(request: Request) {
   // Check rate limit before processing
@@ -15,13 +16,19 @@ export async function POST(request: Request) {
   const { token } = await request.json();
   const secret = process.env.ADMIN_SECRET;
 
-  if (!secret || token !== secret) {
+  if (!secret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const hashedToken = validateAndHashAdminToken(token, secret);
+
+  if (!hashedToken) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const response = NextResponse.json({ ok: true });
 
-  response.cookies.set("admin_token", token, {
+  response.cookies.set("admin_token", hashedToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "strict",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { verifyAdminToken } from "@/utils/auth";
 
 const ADMIN_SECRET = process.env.ADMIN_SECRET;
 
@@ -89,11 +90,19 @@ export function middleware(request: NextRequest) {
 
   const tokenFromCookie = request.cookies.get("admin_token")?.value;
   const tokenFromHeader = request.headers.get("x-admin-token");
-  const token = tokenFromCookie || tokenFromHeader;
 
-  if (ADMIN_SECRET && token === ADMIN_SECRET) {
-    const response = NextResponse.next();
-    return setCorsHeaders(response, origin);
+  if (ADMIN_SECRET) {
+    // Check if cookie contains a hashed token
+    if (tokenFromCookie && verifyAdminToken(ADMIN_SECRET, tokenFromCookie)) {
+      const response = NextResponse.next();
+      return setCorsHeaders(response, origin);
+    }
+
+    // Check if header contains the plaintext secret (for API clients)
+    if (tokenFromHeader && tokenFromHeader === ADMIN_SECRET) {
+      const response = NextResponse.next();
+      return setCorsHeaders(response, origin);
+    }
   }
 
   if (pathname.startsWith("/api/")) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,44 @@
+import crypto from "crypto";
+
+/**
+ * Creates a deterministic hash of the admin token using HMAC-SHA256
+ * This allows for fast verification in middleware while avoiding storing plaintext
+ * @param token - The admin secret
+ * @returns string - The hashed token
+ */
+export function hashAdminToken(token: string): string {
+  // Use a fixed salt for deterministic hashing - in production this could be an env var
+  const salt = "admin_token_salt_2024";
+  return crypto.createHmac("sha256", salt).update(token).digest("hex");
+}
+
+/**
+ * Verifies if a hashed token was generated from the correct admin secret
+ * @param adminSecret - The admin secret to verify against
+ * @param hashedToken - The stored hashed token
+ * @returns boolean - True if the hash matches
+ */
+export function verifyAdminToken(adminSecret: string, hashedToken: string): boolean {
+  try {
+    const expectedHash = hashAdminToken(adminSecret);
+    return crypto.timingSafeEqual(
+      Buffer.from(hashedToken, "hex"),
+      Buffer.from(expectedHash, "hex")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if a token matches the admin secret and returns a hashed version
+ * @param token - The token to verify
+ * @param adminSecret - The admin secret to compare against
+ * @returns string | null - Hashed token if valid, null otherwise
+ */
+export function validateAndHashAdminToken(token: string, adminSecret: string): string | null {
+  if (!adminSecret || token !== adminSecret) {
+    return null;
+  }
+  return hashAdminToken(token);
+}


### PR DESCRIPTION
Implements VO-11

## Summary
- Hash admin tokens using HMAC-SHA256 before storing in cookies
- Update authentication middleware to verify hashed tokens
- Maintain backward compatibility with x-admin-token header for API clients

## Security Improvement
Previously, the admin token was stored as plaintext in cookies, which meant the ADMIN_SECRET was directly exposed. Now we store only a hashed version while maintaining fast verification in middleware.

## Changes
- **New:**  - Admin token hashing utilities
- **Updated:**  - Hash tokens before setting cookies
- **Updated:**  - Verify hashed tokens instead of plaintext comparison

## Test Plan
- [ ] Admin login should work with hashed tokens in cookies
- [ ] API clients can still authenticate with x-admin-token header
- [ ] Middleware correctly rejects invalid tokens