### PR TITLE
Add admin session revoke mechanism (VO-13)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,20 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
+// --- Admin session management ---
+model AdminSession {
+  id        String   @id @default(cuid())
+  token     String   @unique
+  createdAt DateTime @default(now())
+  expiresAt DateTime
+  revokedAt DateTime?
+  ipAddress String?
+  userAgent String?
+
+  @@index([token])
+  @@index([expiresAt])
+}
+
 // --- Uygulama modelleri ---
 model Match {
   id           String   @id @default(cuid())

--- a/src/app/api/admin-auth/revoke/route.ts
+++ b/src/app/api/admin-auth/revoke/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/database/db";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { action, sessionId } = body;
+
+    // Get current session token from cookie or header
+    const tokenFromCookie = request.headers.get("cookie")?.match(/admin_token=([^;]*)/)?.[1];
+    const tokenFromHeader = request.headers.get("x-admin-token");
+    const currentToken = tokenFromCookie || tokenFromHeader;
+
+    if (!currentToken) {
+      return NextResponse.json({ error: "No session found" }, { status: 401 });
+    }
+
+    // Verify current session is valid
+    const currentSession = await prisma.adminSession.findUnique({
+      where: { token: currentToken },
+    });
+
+    if (!currentSession || currentSession.expiresAt < new Date() || currentSession.revokedAt) {
+      return NextResponse.json({ error: "Invalid or expired session" }, { status: 401 });
+    }
+
+    switch (action) {
+      case "current":
+        // Revoke current session (logout)
+        await prisma.adminSession.update({
+          where: { id: currentSession.id },
+          data: { revokedAt: new Date() },
+        });
+
+        const response = NextResponse.json({ success: true, message: "Session revoked" });
+
+        // Clear the cookie
+        response.cookies.set("admin_token", "", {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "strict",
+          path: "/",
+          maxAge: 0,
+        });
+
+        return response;
+
+      case "specific":
+        // Revoke a specific session by ID
+        if (!sessionId) {
+          return NextResponse.json({ error: "Session ID required" }, { status: 400 });
+        }
+
+        const targetSession = await prisma.adminSession.findUnique({
+          where: { id: sessionId },
+        });
+
+        if (!targetSession) {
+          return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
+        if (targetSession.revokedAt) {
+          return NextResponse.json({ error: "Session already revoked" }, { status: 400 });
+        }
+
+        await prisma.adminSession.update({
+          where: { id: sessionId },
+          data: { revokedAt: new Date() },
+        });
+
+        return NextResponse.json({ success: true, message: "Session revoked" });
+
+      case "all":
+        // Revoke all sessions except current one
+        const revokedCount = await prisma.adminSession.updateMany({
+          where: {
+            id: { not: currentSession.id },
+            revokedAt: null,
+            expiresAt: { gt: new Date() },
+          },
+          data: { revokedAt: new Date() },
+        });
+
+        return NextResponse.json({
+          success: true,
+          message: `${revokedCount.count} sessions revoked`,
+          revokedCount: revokedCount.count,
+        });
+
+      case "all_including_current":
+        // Revoke all sessions including current one
+        const allRevokedCount = await prisma.adminSession.updateMany({
+          where: {
+            revokedAt: null,
+            expiresAt: { gt: new Date() },
+          },
+          data: { revokedAt: new Date() },
+        });
+
+        const responseAll = NextResponse.json({
+          success: true,
+          message: `${allRevokedCount.count} sessions revoked`,
+          revokedCount: allRevokedCount.count,
+        });
+
+        // Clear the cookie since current session was also revoked
+        responseAll.cookies.set("admin_token", "", {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "strict",
+          path: "/",
+          maxAge: 0,
+        });
+
+        return responseAll;
+
+      default:
+        return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+    }
+  } catch (error) {
+    console.error("Failed to revoke session:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// GET endpoint to list active sessions
+export async function GET(request: Request) {
+  try {
+    // Get current session token from cookie or header
+    const tokenFromCookie = request.headers.get("cookie")?.match(/admin_token=([^;]*)/)?.[1];
+    const tokenFromHeader = request.headers.get("x-admin-token");
+    const currentToken = tokenFromCookie || tokenFromHeader;
+
+    if (!currentToken) {
+      return NextResponse.json({ error: "No session found" }, { status: 401 });
+    }
+
+    // Verify current session is valid
+    const currentSession = await prisma.adminSession.findUnique({
+      where: { token: currentToken },
+    });
+
+    if (!currentSession || currentSession.expiresAt < new Date() || currentSession.revokedAt) {
+      return NextResponse.json({ error: "Invalid or expired session" }, { status: 401 });
+    }
+
+    // Get all active sessions (not expired and not revoked)
+    const activeSessions = await prisma.adminSession.findMany({
+      where: {
+        expiresAt: { gt: new Date() },
+        revokedAt: null,
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        expiresAt: true,
+        ipAddress: true,
+        userAgent: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json({
+      sessions: activeSessions,
+      currentSessionId: currentSession.id,
+    });
+  } catch (error) {
+    console.error("Failed to list sessions:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin-auth/route.ts
+++ b/src/app/api/admin-auth/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
+import { prisma } from "@/database/db";
 import { adminAuthRateLimiter, getClientIP } from "@/lib/rateLimiter";
-import { validateAndHashAdminToken } from "@/utils/auth";
+import crypto from "crypto";
 
 export async function POST(request: Request) {
   // Check rate limit before processing
@@ -16,25 +17,41 @@ export async function POST(request: Request) {
   const { token } = await request.json();
   const secret = process.env.ADMIN_SECRET;
 
-  if (!secret) {
+  if (!secret || token !== secret) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const hashedToken = validateAndHashAdminToken(token, secret);
+  try {
+    const sessionToken = crypto.randomBytes(32).toString("hex");
+    const expiresAt = new Date(Date.now() + 60 * 60 * 24 * 1000); // 24 hours
 
-  if (!hashedToken) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const userAgent = request.headers.get("user-agent") || undefined;
+    const forwarded = request.headers.get("x-forwarded-for");
+    const realIp = request.headers.get("x-real-ip");
+    const ipAddress = forwarded?.split(",")[0]?.trim() || realIp || "unknown";
+
+    await prisma.adminSession.create({
+      data: {
+        token: sessionToken,
+        expiresAt,
+        ipAddress: ipAddress !== "unknown" ? ipAddress : undefined,
+        userAgent,
+      },
+    });
+
+    const response = NextResponse.json({ ok: true });
+
+    response.cookies.set("admin_token", sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      path: "/",
+      maxAge: 60 * 60 * 24, // 24 hours to match DB session
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Failed to create admin session:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  const response = NextResponse.json({ ok: true });
-
-  response.cookies.set("admin_token", hashedToken, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "strict",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 7,
-  });
-
-  return response;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { verifyAdminToken } from "@/utils/auth";
+import { prisma } from "@/database/db";
 
 const ADMIN_SECRET = process.env.ADMIN_SECRET;
 
@@ -26,7 +26,7 @@ const ADMIN_ONLY_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 const ADMIN_API_PATHS = [
   "/api/matches",
   "/api/incidents",
-  "/api/suggestions", // PATCH/DELETE /api/suggestions/[id] admin only; POST /api/suggestions user auth (API'de kontrol)
+  "/api/suggestions",
   "/api/commentators",
   "/api/referees",
   "/api/opinions",
@@ -39,7 +39,6 @@ function isProtectedPath(pathname: string): boolean {
 }
 
 function isAdminApiWrite(pathname: string, method: string): boolean {
-  // POST /api/suggestions: kullanıcı girişi (NextAuth) - API kendi auth kontrolü yapar
   if (pathname === "/api/suggestions" && method === "POST") return false;
   return (
     ADMIN_ONLY_METHODS.includes(method) &&
@@ -53,15 +52,12 @@ function setCorsHeaders(response: NextResponse, origin: string | null): NextResp
   if (origin && CORS_ORIGINS.includes(origin)) {
     response.headers.set("Access-Control-Allow-Origin", origin);
   } else if (process.env.NODE_ENV === "development") {
-    // Allow any origin in development
     response.headers.set("Access-Control-Allow-Origin", "*");
   }
-
   response.headers.set("Access-Control-Allow-Methods", CORS_METHODS.join(", "));
   response.headers.set("Access-Control-Allow-Headers", CORS_HEADERS.join(", "));
   response.headers.set("Access-Control-Allow-Credentials", "true");
-  response.headers.set("Access-Control-Max-Age", "86400"); // 24 hours
-
+  response.headers.set("Access-Control-Max-Age", "86400");
   return response;
 }
 
@@ -71,12 +67,11 @@ function handleCorsPrelight(request: NextRequest): NextResponse {
   return setCorsHeaders(response, origin);
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const method = request.method;
   const origin = request.headers.get("origin");
 
-  // Handle CORS preflight requests
   if (method === "OPTIONS") {
     return handleCorsPrelight(request);
   }
@@ -90,16 +85,40 @@ export function middleware(request: NextRequest) {
 
   const tokenFromCookie = request.cookies.get("admin_token")?.value;
   const tokenFromHeader = request.headers.get("x-admin-token");
+  const token = tokenFromCookie || tokenFromHeader;
 
-  if (ADMIN_SECRET) {
-    // Check if cookie contains a hashed token
-    if (tokenFromCookie && verifyAdminToken(ADMIN_SECRET, tokenFromCookie)) {
+  if (!token) {
+    if (pathname.startsWith("/api/")) {
+      const response = NextResponse.json({ error: "Not found" }, { status: 404 });
+      return setCorsHeaders(response, origin);
+    }
+    return NextResponse.rewrite(new URL("/not-found", request.url));
+  }
+
+  try {
+    const session = await prisma.adminSession.findUnique({
+      where: { token },
+    });
+
+    if (session) {
+      const now = new Date();
+      if (session.expiresAt > now && !session.revokedAt) {
+        const response = NextResponse.next();
+        return setCorsHeaders(response, origin);
+      }
+      if (session.expiresAt <= now) {
+        await prisma.adminSession.delete({ where: { id: session.id } });
+      }
+    }
+
+    // Fallback: direct admin secret check (for backward compatibility)
+    if (ADMIN_SECRET && token === ADMIN_SECRET) {
       const response = NextResponse.next();
       return setCorsHeaders(response, origin);
     }
-
-    // Check if header contains the plaintext secret (for API clients)
-    if (tokenFromHeader && tokenFromHeader === ADMIN_SECRET) {
+  } catch (error) {
+    console.error("Middleware auth error:", error);
+    if (ADMIN_SECRET && token === ADMIN_SECRET) {
       const response = NextResponse.next();
       return setCorsHeaders(response, origin);
     }


### PR DESCRIPTION
## Summary
Implements admin session revoke mechanism to replace insecure 7-day cookies with DB-backed sessions.

## Changes
- ✅ Add AdminSession model to Prisma schema with revokable sessions
- ✅ Replace 7-day cookies with 24-hour DB-backed sessions  
- ✅ Add session revoke endpoint supporting multiple actions (current, specific, all)
- ✅ Update middleware to validate against database sessions
- ✅ Maintain backward compatibility with direct admin secret check
- ✅ Include IP address and user agent tracking for better security

## API Endpoints
- **POST /api/admin-auth/revoke** - Revoke sessions (current, specific, all, all_including_current)
- **GET /api/admin-auth/revoke** - List active sessions with metadata

## Security Improvements
- Session tokens are now cryptographically secure (32-byte random)
- Sessions expire in 24 hours instead of 7 days
- Sessions can be revoked immediately by administrators
- IP address and User-Agent tracking for session audit trails
- Automatic cleanup of expired sessions

## Backward Compatibility
- Direct admin secret check remains as fallback
- Existing admin workflows continue to work
- Graceful degradation on database errors

🤖 Implements VO-13