### PR TITLE
feat: add Zod validation to match-videos POST endpoint

### DIFF
--- a/src/app/api/match-videos/route.ts
+++ b/src/app/api/match-videos/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/database/db";
 import { NO_CACHE_HEADERS } from "@/lib/api-response";
+import { MatchVideoPostSchema, parseBody } from "@/lib/schemas";
 
 export async function GET(request: NextRequest) {
   try {
@@ -36,25 +37,22 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { matchId, videoUrl, title, durationMin, transcript, source, notes } = body;
-
-    if (!matchId || !videoUrl) {
-      return NextResponse.json(
-        { error: "matchId ve videoUrl gerekli" },
-        { status: 400 }
-      );
+    const rawBody = await request.json();
+    const parsed = parseBody(MatchVideoPostSchema, rawBody);
+    if ("error" in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: parsed.status });
     }
+    const { matchId, videoUrl, title, durationMin, transcript, source, notes } = parsed.data;
 
     const video = await prisma.matchVideo.create({
       data: {
         matchId,
-        videoUrl: String(videoUrl).trim(),
-        title: title?.trim() || null,
-        durationMin: durationMin != null ? parseInt(String(durationMin), 10) : null,
-        transcript: transcript?.trim() || null,
-        source: source?.trim() || "youtube",
-        notes: notes?.trim() || null,
+        videoUrl,
+        title: title ?? null,
+        durationMin: durationMin ?? null,
+        transcript: transcript ?? null,
+        source,
+        notes: notes ?? null,
       },
       include: {
         match: {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -22,6 +22,16 @@ export const SuggestionPostSchema = z.object({
   message: z.string().trim().min(1, "Mesaj alanı zorunludur").max(3000, "Mesaj en fazla 3000 karakter olabilir"),
 });
 
+export const MatchVideoPostSchema = z.object({
+  matchId: z.string().min(1, "matchId gerekli"),
+  videoUrl: z.string().url("Geçerli bir URL giriniz").min(1, "videoUrl gerekli"),
+  title: z.string().trim().max(500).optional(),
+  durationMin: z.number().int().min(0).max(600).optional().nullable(),
+  transcript: z.string().trim().max(50000).optional().nullable(),
+  source: z.enum(["youtube", "twitter", "instagram", "other"]).optional().default("youtube"),
+  notes: z.string().trim().max(5000).optional().nullable(),
+});
+
 export const UserProfilePatchSchema = z.object({
   name: z.string().trim().min(1).max(100).optional(),
   nickname: z.string().trim().min(1).max(50).optional(),


### PR DESCRIPTION
## Summary

- Add `MatchVideoPostSchema` to `src/lib/schemas.ts` with proper validation rules:
  - `matchId`: required string
  - `videoUrl`: required, must be valid URL
  - `title`: optional, max 500 chars
  - `durationMin`: optional int, 0–600 range
  - `source`: enum `youtube | twitter | instagram | other`, defaults to `youtube`
  - `transcript` / `notes`: optional with max length limits
- Replace manual `if (!matchId || !videoUrl)` check in POST handler with `parseBody(MatchVideoPostSchema, ...)`
- Consistent with existing Zod validation pattern used in `comments`, `votes`, `suggestions` routes

## Test plan
- [ ] POST with missing `matchId` → 400 with error message
- [ ] POST with invalid URL in `videoUrl` → 400 with validation error
- [ ] POST with `source: "invalid"` → 400
- [ ] POST with valid payload → 201 with created video

🤖 Generated with [Claude Code](https://claude.com/claude-code)