### PR TITLE
perf: switch match-videos and var-events GET to PUBLIC_CACHE_HEADERS

### DIFF
--- a/src/app/api/match-videos/route.ts
+++ b/src/app/api/match-videos/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/database/db";
-import { NO_CACHE_HEADERS } from "@/lib/api-response";
+import { NO_CACHE_HEADERS, PUBLIC_CACHE_HEADERS } from "@/lib/api-response";
 import { MatchVideoPostSchema, parseBody } from "@/lib/schemas";
 
 export async function GET(request: NextRequest) {
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: "desc" },
     });
 
-    return NextResponse.json(videos, { headers: NO_CACHE_HEADERS });
+    return NextResponse.json(videos, { headers: PUBLIC_CACHE_HEADERS });
   } catch (err) {
     console.error("GET /api/match-videos error:", err);
     return NextResponse.json([], { headers: NO_CACHE_HEADERS });

--- a/src/app/api/var-events/route.ts
+++ b/src/app/api/var-events/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/database/db";
-import { NO_CACHE_HEADERS } from "@/lib/api-response";
+import { NO_CACHE_HEADERS, PUBLIC_CACHE_HEADERS } from "@/lib/api-response";
 
 /** VAR müdahale analizi - Incident.varIntervention ve VarEvent tablosundan */
 export async function GET(request: NextRequest) {
@@ -65,7 +65,7 @@ export async function GET(request: NextRequest) {
           match: i.match,
         })),
       },
-      { headers: NO_CACHE_HEADERS }
+      { headers: PUBLIC_CACHE_HEADERS }
     );
   } catch (err) {
     console.error("GET /api/var-events error:", err);


### PR DESCRIPTION
## Summary

- `GET /api/match-videos` — changed from `NO_CACHE_HEADERS` to `PUBLIC_CACHE_HEADERS`
- `GET /api/var-events` — changed from `NO_CACHE_HEADERS` to `PUBLIC_CACHE_HEADERS`
- Both endpoints serve read-heavy, infrequently mutated data (videos added by admin, VAR event summaries)
- CDN now caches responses for 60s fresh + 300s stale-while-revalidate, reducing unnecessary DB hits

`PUBLIC_CACHE_HEADERS` was already defined in `lib/api-response.ts` and used by `matches`, `referees`, `commentators`, and `statistics` routes — this PR brings consistency.

## Test plan
- [ ] GET /api/match-videos returns `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`
- [ ] GET /api/var-events returns same header
- [ ] POST /api/match-videos still returns no-cache response (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)