### PR TITLE
feat(seo): extend robots.txt — disallow /crawler and /giris

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/dashboard', '/admin-login', '/api/'],
+      disallow: ['/dashboard', '/admin-login', '/api/', '/crawler', '/giris'],
     },
     sitemap: `${process.env.NEXTAUTH_URL || 'https://varodasiapp.com'}/sitemap.xml`,
   }


### PR DESCRIPTION
## Summary
- Adds /crawler and /giris to robots.ts Disallow rules
- Prevents admin-facing and auth-entry routes from being indexed

## Test plan
- [ ] curl /robots.txt shows updated Disallow rules
- [ ] No public routes accidentally blocked

Closes #21