### PR TITLE
feat(analytics): add custom events — suggestion_submit + chat_message_sent

### DIFF
--- a/src/app/oneri/page.tsx
+++ b/src/app/oneri/page.tsx
@@ -13,6 +13,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import AuthModal from "@/components/AuthModal";
+import { track } from "@vercel/analytics";
 
 const CATEGORIES = [
   { value: "GENERAL", label: "Genel", icon: <MessageSquare className="h-4 w-4" /> },
@@ -69,6 +70,7 @@ export default function SuggestionPage() {
       });
 
       if (res.ok) {
+        track("suggestion_submit", { category });
         setSuccess(true);
         setCategory("GENERAL");
         setSubject("");

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { Send, Loader2, Bot, User } from "lucide-react";
+import { track } from "@vercel/analytics";
 
 interface Message {
   role: "user" | "assistant";
@@ -28,6 +29,7 @@ export default function ChatInterface({ matchId }: ChatInterfaceProps) {
     const userMessage: Message = { role: "user", content: input.trim() };
     const newMessages = [...messages, userMessage];
     setMessages(newMessages);
+    track("chat_message_sent", { matchId: matchId ?? "global", messageIndex: newMessages.length });
     setInput("");
     setLoading(true);
 


### PR DESCRIPTION
## Summary
- suggestion_submit: tracked with category when form submitted successfully (/oneri)
- chat_message_sent: tracked with matchId + messageIndex in ChatInterface
- Extends existing vote/comment tracking to cover key user journeys

## Test plan
- [ ] Submit suggestion form → check Vercel Analytics events
- [ ] Send AI chat message → event appears in dashboard
- [ ] No tracking on failed submissions (server errors)